### PR TITLE
Fix initial loading state when fireOnMount is false

### DIFF
--- a/src/useData.ts
+++ b/src/useData.ts
@@ -98,7 +98,7 @@ export function useData<D>(
   });
 
   const [state, dispatch] = useReducer(dataFetchReducer<D>(), {
-    loading: true,
+    loading: fireOnMount,
     error: null,
     data: initialData || null,
   });


### PR DESCRIPTION
`fireOnMount` indeed prevents fetching, but the initial loading state was still being set to true.